### PR TITLE
Update .npmignore to include examples and dist directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 .yarn
+examples
+dist/examples
+*.glb


### PR DESCRIPTION
The .npmignore file now excludes the examples and dist directories to prevent unnecessary files from being published.