### PR TITLE
fix #98

### DIFF
--- a/src/controls/TransformShapeControls/TransformShapeControls.ts
+++ b/src/controls/TransformShapeControls/TransformShapeControls.ts
@@ -1538,12 +1538,12 @@ class TransformShapeControlsGizmo extends THREE.Object3D {
 			"position",
 			new THREE.Float32BufferAttribute([0, 0, 0, 1, 0, 0], 3),
 		);
-		// lineGeometry.computeBoundsTree();
+		lineGeometry.computeBoundsTree();
 
 		const lineGeometry2 = new THREE.CylinderGeometry(0.0075, 0.0075, 0.5, 3);
 		lineGeometry2.translate(0, 0.25, 0);
 
-		// lineGeometry2.computeBoundsTree();
+		lineGeometry2.computeBoundsTree();
 
 		function CircleGeometry(radius: number, arc: number) {
 			const geometry = new THREE.TorusGeometry(
@@ -1553,7 +1553,7 @@ class TransformShapeControlsGizmo extends THREE.Object3D {
 				64,
 				arc * Math.PI * 2,
 			);
-			// geometry.computeBoundsTree();
+			geometry.computeBoundsTree();
 			geometry.rotateY(Math.PI / 2);
 			geometry.rotateX(Math.PI / 2);
 			return geometry;
@@ -2092,7 +2092,7 @@ class TransformShapeControlsGizmo extends THREE.Object3D {
 			parent.forEach((array: any[]) => {
 				array.forEach((object: THREE.Mesh) => {
 					if (!object?.geometry) return;
-					// object.geometry.computeBoundsTree();
+					object.geometry.computeBoundsTree();
 				});
 			});
 		});


### PR DESCRIPTION
Activate bounds tree computation for various geometries within the TransformShapeControlsGizmo class to improve performance and rendering efficiency.